### PR TITLE
Added Level colours only feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ go get github.com/rocajuanma/palantir
 - Emoji support
 - Progress indicators
 - Interactive confirmations
+- Level-only colour mode for subtle highlight of status prefixes
 
 
 <p align="center">

--- a/cmd/terminal/README.md
+++ b/cmd/terminal/README.md
@@ -16,6 +16,7 @@ go build -o palantir-demo ./cmd/terminal
 ## Output
 
 - Multiple configurations available
+- Level-only colouring available for subtler emphasis
 - All output levels (Header, Info, Success, Warning, Error, Stage)
 - Progress indicators
 - Interactive confirmations
@@ -26,5 +27,4 @@ go build -o palantir-demo ./cmd/terminal
 <p align="center">
   <img src="terminal.png" alt="Palantir Demo">
 </p>
-
 

--- a/cmd/terminal/main.go
+++ b/cmd/terminal/main.go
@@ -25,6 +25,30 @@ func main() {
 		handler.PrintInfo("User declined")
 	}
 
+	// Setup configuration that only colours the output level indicator
+	levelColoursConfig := &terminal.OutputConfig{
+		UseColors:         true,
+		UseEmojis:         false,
+		UseFormatting:     true,
+		DisableOutput:     false,
+		ColorizeLevelOnly: true,
+	}
+
+	levelColours := terminal.NewOutputHandler(levelColoursConfig)
+	levelColours.PrintHeader("Palantir Demo(Level Colours Only)")
+	levelColours.PrintInfo("This is an info message")
+	levelColours.PrintSuccess("Operation completed successfully!")
+	levelColours.PrintWarning("This is a warning message")
+	levelColours.PrintError("This is an error message")
+	levelColours.PrintStage("Processing stage 1")
+	levelColours.PrintAlreadyAvailable("Feature is already available")
+	levelColours.PrintProgress(3, 10, "Processing items")
+	if levelColours.Confirm("Do you want to continue?") {
+		levelColours.PrintSuccess("User confirmed!")
+	} else {
+		levelColours.PrintInfo("User declined")
+	}
+
 	// Setup configurations with colours only
 	coloursOnlyConfig := &terminal.OutputConfig{
 		UseColors:     true,


### PR DESCRIPTION
This PR introduces a configurable “level-only” colorization mode. Instead of tinting the entire message when colors are enabled, this mode applies color only to prefixes (e.g., [SUCCESS], emojis, headers, progress labels) while keeping descriptive text plain.

Reasolves Issue #7 