### PR TITLE
feat[tree]: extend tree to support yaml content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,17 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- **Tree Visualization System**: New hierarchical tree display functionality
-  - `ShowHierarchy()` function for displaying directory structures as ASCII trees
-  - Support for filesystem traversal with proper directory/file distinction
-  - Color-coded file types (Go files, Markdown, JSON, YAML, shell scripts)
-  - Configurable tree display with constants for tree characters (├──, └──, │, etc.)
+- **Tree Visualization System**
+  - New hierarchical tree display functionality for directories and files
+  - Color-coded file types (Go, Markdown, JSON, YAML, shell scripts)
+  - Enhanced tree display for YAML content
+  - Support for nested YAML structures with color-coded node types
+  - Integrated with OutputConfig for consistent styling
+  - Comprehensive test coverage for all tree logic
 
 ### Changed
+- Enhanced README with comprehensive tree visualization examples, better feature list and update usage section
+- Updated `main.go` in demo to showcase new tree visualization features
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ A lightweight Go package for enhanced terminal output, featuring colored text, e
 
 > In *The Lord of the Rings* lore, a Palantír is a seeing-stone that enables users to communicate and observe distant events. Similarly, this package empowers you to gain clearer insights into your program's output, making it easier to monitor and understand what's happening.
 
+## Features
+- **Multiple Output Levels:** Easily distinguish between informational messages, warnings, errors, successes, headers, and stages with dedicated methods for each.
+- **Flexible Colored Output:** Choose between fully-colored lines, colorizing only the output level, or disabling colors entirely to suit your terminal or preferences.
+- **Tree Visualization:** Visualize files, directories, and YAML content in a structured tree format for easier navigation and understanding.
+- **Progress Indicators:** Display animated progress spinners or status updates to track ongoing operations in real time.
+- **Interactive Confirmations:** Prompt users for confirmation or input directly in the terminal, supporting interactive workflows.
+- **Customizable Configuration:** Fine-tune output behavior with options for verbosity, formatting, color usage, and emoji toggling.
 
 ## Installation
 
@@ -43,6 +50,30 @@ func main() {
     handler.PrintWarning("This is a warning")
     handler.PrintError("Something went wrong")
     handler.PrintStage("Processing stage 1")
+
+    // Display directory tree structure
+    err, _ := palantir.ShowHierarchy("/path/to/directory", "")
+    if err != nil {
+        panic(err)
+    }
+
+    // Display YAML content in tree structure
+    yamlContent, err := os.ReadFile("config.yaml")
+    if err != nil {
+        panic(err)
+    }
+    
+    // Display YAML as tree structure
+    err = palantir.ShowYAMLHierarchy(yamlContent)
+    if err != nil {
+        panic(err)
+    }
+    
+    // Or read from file directly
+    err = palantir.ShowYAMLHierarchyFromFile("config.yaml")
+    if err != nil {
+        panic(err)
+    }
 }
 ```
 
@@ -62,18 +93,11 @@ config := &palantir.OutputConfig{
 handler := palantir.NewOutputHandler(config)
 ```
 
-## Features
-
-- Multiple output levels
-- Colored output: fully-coloured line, level-only or no-colour
-- Emoji support
-- Progress indicators
-- Interactive confirmations
-
+Check out the [Palantir demo](cmd/demo/README.md) for detailed usage examples, advanced capabilities, and interactive feature showcases.
 
 <p align="center">
   <img src="./assets/terminal.png" alt="Palantir Demo">
 </p>
 
 
-See the [Palantir terminal demo](cmd/demo/README.md) for usage examples.
+

--- a/cmd/demo/README.md
+++ b/cmd/demo/README.md
@@ -1,4 +1,4 @@
-# Palantir Terminal Demo
+# Palantir Demo
 
 A simple demonstration of the Palantir terminal formatting package.
 
@@ -12,18 +12,6 @@ go run ./cmd/demo
 go build -o palantir-demo ./cmd/demo
 ./palantir-demo
 ```
-
-## Output
-
-- Multiple configurations available
-- Level-only colouring available for subtler emphasis
-- All output levels (Header, Info, Success, Warning, Error, Stage)
-- Progress indicators
-- Interactive confirmations
-- Colour and emoji formatting
-- Visualizes directory and file structures as a tree
-
-
 
 <p align="center">
   <img src="../../assets/terminal.png" alt="Palantir Demo">

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -5,6 +5,32 @@ import (
 )
 
 func main() {
+	// Sample YAML content
+	yamlContent := []byte(`
+database:
+  host: localhost
+  port: 5432
+  credentials:
+    username: admin
+    password: secret
+  tables:
+    - users
+    - posts
+    - comments
+server:
+  host: 0.0.0.0
+  port: 8080
+  debug: true
+  features:
+    - authentication
+    - logging
+    - monitoring
+redis:
+  host: redis-server
+  port: 6379
+  database: 0
+`)
+
 	// Initialize the default output handler(all features enabled)
 	handler := palantir.NewDefaultOutputHandler()
 
@@ -96,61 +122,26 @@ func main() {
 
 	// File Tree demo
 	handler.PrintHeader("File/Directory Tree Visualization")
-	handler.PrintStage("Tree with different output configurations")
+	handler.PrintStage("Tree with colours")
 
-	// Show tree of current directory
-	handler.PrintInfo("Displaying tree structure of current directory:")
-	err, hasHierarchy := palantir.ShowHierarchy(".", "")
+	// Colours enabled by default
+	err, _ := palantir.ShowHierarchy(".", "")
 	if err != nil {
 		handler.PrintError("Failed to display tree: %v", err)
-	} else if hasHierarchy {
-		handler.PrintSuccess("Tree displayed successfully!\n")
-	} else {
-		handler.PrintInfo("No hierarchy to display (single file)")
 	}
 
-	// Tree with colors disabled
-	handler.PrintInfo("Tree with colours disabled:")
+	// Tree with colours disabled
+	handler.PrintStage("Tree with without colours")
 	palantir.SetGlobalOutputHandler(noColours)
-	err, hasHierarchy = palantir.ShowHierarchy(".", "")
+	err, _ = palantir.ShowHierarchy(".", "")
 	if err != nil {
 		handler.PrintError("Failed to display tree: %v", err)
 	}
-
-	// Sample YAML content
-	yamlContent := []byte(`
-database:
-  host: localhost
-  port: 5432
-  credentials:
-    username: admin
-    password: secret
-  tables:
-    - users
-    - posts
-    - comments
-server:
-  host: 0.0.0.0
-  port: 8080
-  debug: true
-  features:
-    - authentication
-    - logging
-    - monitoring
-redis:
-  host: redis-server
-  port: 6379
-  database: 0
-`)
 
 	// YAML Tree demo
 	handler.PrintHeader("YAML Tree Visualization")
 	err = palantir.ShowYAMLHierarchy(yamlContent)
 	if err != nil {
 		handler.PrintError("Failed to display YAML tree: %v", err)
-	} else {
-		handler.PrintSuccess("YAML tree displayed successfully!\n")
 	}
-
-	handler.PrintSuccess("Tree system demonstration completed!")
 }

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -94,8 +94,8 @@ func main() {
 		noColours.PrintInfo("User declined")
 	}
 
-	// Tree demo
-	handler.PrintHeader("Tree Output Demo")
+	// File Tree demo
+	handler.PrintHeader("File/Directory Tree Visualization")
 	handler.PrintStage("Tree with different output configurations")
 
 	// Show tree of current directory
@@ -115,6 +115,41 @@ func main() {
 	err, hasHierarchy = palantir.ShowHierarchy(".", "")
 	if err != nil {
 		handler.PrintError("Failed to display tree: %v", err)
+	}
+
+	// Sample YAML content
+	yamlContent := []byte(`
+database:
+  host: localhost
+  port: 5432
+  credentials:
+    username: admin
+    password: secret
+  tables:
+    - users
+    - posts
+    - comments
+server:
+  host: 0.0.0.0
+  port: 8080
+  debug: true
+  features:
+    - authentication
+    - logging
+    - monitoring
+redis:
+  host: redis-server
+  port: 6379
+  database: 0
+`)
+
+	// YAML Tree demo
+	handler.PrintHeader("YAML Tree Visualization")
+	err = palantir.ShowYAMLHierarchy(yamlContent)
+	if err != nil {
+		handler.PrintError("Failed to display YAML tree: %v", err)
+	} else {
+		handler.PrintSuccess("YAML tree displayed successfully!\n")
 	}
 
 	handler.PrintSuccess("Tree system demonstration completed!")

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/rocajuanma/palantir
 
 go 1.23.6
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
# Add YAML Tree Visualization Support

## Summary
This MR adds comprehensive YAML tree visualization capabilities to Palantir, extending the existing directory tree functionality to support YAML content display.

## Features Added
- **YAML Tree Display**: `ShowYAMLHierarchy()` and `ShowYAMLHierarchyFromFile()` functions
- **Programmatic Parsing**: `ParseYAMLToTree()` for custom tree processing
- **Clean Array Display**: Shows array values without indices (e.g., "users" instead of "[0]: users")
- **Color-coded Nodes**: Different colors for objects, arrays, and scalars
- **Configuration Integration**: Works with existing OutputConfig settings

## Technical Details
- Performance-optimized tree building with O(1) lookup using maps
- Comprehensive test coverage with table-driven test patterns
- Generic `TreeNode` structure supporting both filesystem and YAML data
- Clean separation of concerns with minimal code duplication


## Example Usage
```go
// Display YAML from file
err := palantir.ShowYAMLHierarchyFromFile("config.yaml")

// Parse YAML programmatically
root, err := palantir.ParseYAMLToTree(yamlContent)
```
